### PR TITLE
refactor atomic physics code

### DIFF
--- a/include/picongpu/particles/atomicPhysics2/DeltaEnergyTransition.hpp
+++ b/include/picongpu/particles/atomicPhysics2/DeltaEnergyTransition.hpp
@@ -78,15 +78,13 @@ namespace picongpu::particles::atomicPhysics2
             uint8_t const upperStateChargeState,
             T_ChargeStateDataBox const chargeStateDataBox)
         {
-            if constexpr(u8(T_ProcessClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased))
+            constexpr bool isValidTransitionType
+                = u8(T_ProcessClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased)
+                || u8(T_ProcessClassGroup) == u8(s_enums::ProcessClassGroup::autonomousBased);
+            if constexpr(isValidTransitionType)
                 return ionizationEnergyHelper<T_ChargeStateDataBox>(
                     lowerStateChargeState,
                     upperStateChargeState,
-                    chargeStateDataBox);
-            if constexpr(u8(T_ProcessClassGroup) == u8(s_enums::ProcessClassGroup::autonomousBased))
-                return ionizationEnergyHelper<T_ChargeStateDataBox>(
-                    upperStateChargeState,
-                    lowerStateChargeState,
                     chargeStateDataBox);
             else
             {

--- a/include/picongpu/particles/atomicPhysics2/kernel/ChooseTransition_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics2/kernel/ChooseTransition_BoundBound.kernel
@@ -160,12 +160,15 @@ namespace picongpu::particles::atomicPhysics2::kernel
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
             auto& rateCache = localRateCacheBox(superCellFieldIdx);
             T_Histogram& electronHistogram = localElectronHistogramDataBox(superCellFieldIdx);
-            
+
             // UNIT_LENGTH^3
             constexpr float_X volumeScalingFactor
                 = pmacc::math::CT::volume<SuperCellSize>::type::value * picongpu::CELL_VOLUME;
 
-            PMACC_SMEM(worker, cachedHistogram, CachedHistogram<electronicChannelActive ? T_Histogram::numberBins: 0>);
+            PMACC_SMEM(
+                worker,
+                cachedHistogram,
+                CachedHistogram < electronicChannelActive ? T_Histogram::numberBins : 0 >);
             // no need to fill the histogram cache if we do not use the histogram
             if(electronicChannelActive)
                 cachedHistogram.fill(worker, electronHistogram, volumeScalingFactor);
@@ -235,8 +238,6 @@ namespace picongpu::particles::atomicPhysics2::kernel
                                 // 1/UNIT_TIME
                                 float_X const rateTransition = picongpu::particles::atomicPhysics2::rateCalculation::
                                     BoundBoundTransitionRates<T_n_max>::template rateCollisionalBoundBoundTransition<
-                                        T_AtomicStateDataDataBox,
-                                        T_BoundBoundTransitionDataBox,
                                         isUpward>(
                                         cachedHistogram.energy[binIndex],
                                         cachedHistogram.binWidth[binIndex],
@@ -289,9 +290,7 @@ namespace picongpu::particles::atomicPhysics2::kernel
 
                             // 1/UNIT_TIME
                             float_X const rateTransition = picongpu::particles::atomicPhysics2::rateCalculation::
-                                BoundBoundTransitionRates<T_n_max>::template rateSpontaneousRadiativeDeexcitation<
-                                    T_AtomicStateDataDataBox,
-                                    T_BoundBoundTransitionDataBox>(
+                                BoundBoundTransitionRates<T_n_max>::rateSpontaneousRadiativeDeexcitation(
                                     transitionID + startIndexTransitionBlock,
                                     atomicStateDataDataBox,
                                     transitionDataBox);

--- a/include/picongpu/particles/atomicPhysics2/kernel/ChooseTransition_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics2/kernel/ChooseTransition_BoundFree.kernel
@@ -204,10 +204,7 @@ namespace picongpu::particles::atomicPhysics2::kernel
                             {
                                 // 1/UNIT_TIME
                                 float_X const rateTransition = picongpu::particles::atomicPhysics2::rateCalculation::
-                                    BoundFreeTransitionRates<T_n_max>::template rateCollisionalIonizationTransition<
-                                        T_ChargeStateDataDataBox,
-                                        T_AtomicStateDataDataBox,
-                                        T_BoundFreeTransitionDataBox>(
+                                    BoundFreeTransitionRates<T_n_max>::rateCollisionalIonizationTransition(
                                         cachedHistogram.energy[binIndex],
                                         cachedHistogram.binWidth[binIndex],
                                         cachedHistogram.density[binIndex],

--- a/include/picongpu/particles/atomicPhysics2/kernel/FillLocalRateCache_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics2/kernel/FillLocalRateCache_BoundBound.kernel
@@ -192,46 +192,21 @@ namespace picongpu::particles::atomicPhysics2::kernel
                         for(uint32_t transitionID = static_cast<uint32_t>(0u); transitionID < numberTransitions;
                             ++transitionID)
                         {
-                            // electronic excitation
-                            if constexpr(isUpward)
-                            {
-                                rateCache.template add<T_Worker, s_enums::TransitionDataSet::boundBoundUpward>(
-                                    worker,
-                                    atomicStateCollectionIndex,
-                                    // rate
-                                    picongpu::particles::atomicPhysics2::rateCalculation::BoundBoundTransitionRates<
-                                        T_numberLevels>::
-                                        template rateCollisionalBoundBoundTransition<
-                                            T_AtomicStateDataDataBox,
-                                            T_BoundBoundTransitionDataBox,
-                                            isUpward>(
-                                            energy,
-                                            binWidth,
-                                            density,
-                                            offset + transitionID,
-                                            atomicStateDataDataBox,
-                                            boundBoundTransitionDataBox));
-                            }
-                            // electronic deexcitation
-                            else
-                            {
-                                rateCache.template add<T_Worker, s_enums::TransitionDataSet::boundBoundDownward>(
-                                    worker,
-                                    atomicStateCollectionIndex,
-                                    // rate
-                                    picongpu::particles::atomicPhysics2::rateCalculation::BoundBoundTransitionRates<
-                                        T_numberLevels>::
-                                        template rateCollisionalBoundBoundTransition<
-                                            T_AtomicStateDataDataBox,
-                                            T_BoundBoundTransitionDataBox,
-                                            isUpward>(
-                                            energy,
-                                            binWidth,
-                                            density,
-                                            offset + transitionID,
-                                            atomicStateDataDataBox,
-                                            boundBoundTransitionDataBox));
-                            }
+                            constexpr auto dataSet = isUpward ? s_enums::TransitionDataSet::boundBoundUpward
+                                                              : s_enums::TransitionDataSet::boundBoundDownward;
+                            rateCache.template atomicAdd<dataSet>(
+                                worker,
+                                atomicStateCollectionIndex,
+                                // rate
+                                picongpu::particles::atomicPhysics2::rateCalculation::BoundBoundTransitionRates<
+                                    T_numberLevels>::
+                                    template rateCollisionalBoundBoundTransition<isUpward>(
+                                        energy,
+                                        binWidth,
+                                        density,
+                                        offset + transitionID,
+                                        atomicStateDataDataBox,
+                                        boundBoundTransitionDataBox));
                         }
                     });
             }
@@ -265,9 +240,7 @@ namespace picongpu::particles::atomicPhysics2::kernel
                                 // rate
                                 picongpu::particles::atomicPhysics2::rateCalculation::BoundBoundTransitionRates<
                                     T_numberLevels>::
-                                    template rateSpontaneousRadiativeDeexcitation<
-                                        T_AtomicStateDataDataBox,
-                                        T_BoundBoundTransitionDataBox>(
+                                    template rateSpontaneousRadiativeDeexcitation(
                                         // transitionCollectionIndex
                                         offset + transitionID,
                                         atomicStateDataDataBox,

--- a/include/picongpu/particles/atomicPhysics2/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics2/kernel/FillLocalRateCache_BoundFree.kernel
@@ -184,15 +184,11 @@ namespace picongpu::particles::atomicPhysics2::kernel
                     {
                         if constexpr(T_electronicIonization)
                         {
-                            rateCache.template add<T_Worker, s_enums::TransitionDataSet::boundFreeUpward>(
+                            rateCache.template atomicAdd<s_enums::TransitionDataSet::boundFreeUpward>(
                                 worker,
                                 atomicStateCollectionIndex,
-                                picongpu::particles::atomicPhysics2::rateCalculation::BoundFreeTransitionRates<
-                                    T_numberLevels>::
-                                    template rateCollisionalIonizationTransition<
-                                        T_ChargeStateDataDataBox,
-                                        T_AtomicStateDataDataBox,
-                                        T_BoundFreeTransitionDataBox>(
+                                picongpu::particles::atomicPhysics2::rateCalculation::
+                                    BoundFreeTransitionRates<T_numberLevels>::rateCollisionalIonizationTransition(
                                         energy,
                                         binWidth,
                                         density,

--- a/include/picongpu/particles/atomicPhysics2/localHelperFields/RateCache.hpp
+++ b/include/picongpu/particles/atomicPhysics2/localHelperFields/RateCache.hpp
@@ -82,8 +82,8 @@ namespace picongpu::particles::atomicPhysics2::localHelperFields
          *
          * @attention no range checks outside a debug compile, invalid memory write on failure
          */
-        template<typename T_Worker, particles::atomicPhysics2::enums::TransitionDataSet T_TransitionDataSet>
-        HDINLINE void add(T_Worker const& worker, uint32_t const collectionIndex, float_X rate)
+        template<particles::atomicPhysics2::enums::TransitionDataSet T_TransitionDataSet, typename T_Worker>
+        HDINLINE void atomicAdd(T_Worker const& worker, uint32_t const collectionIndex, float_X rate)
         {
             PMACC_CASSERT_MSG(
                 noChange_not_allowed_as_T_TransitionDataSet,

--- a/include/picongpu/particles/atomicPhysics2/rateCalculation/BoundBoundTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics2/rateCalculation/BoundBoundTransitionRates.hpp
@@ -309,7 +309,7 @@ namespace picongpu::particles::atomicPhysics2::rateCalculation
          *
          * @return unit: 1/UNIT_TIME
          */
-        template<typename T_AtomicStateDataBox, typename T_BoundBoundTransitionDataBox, bool T_excitation>
+        template<bool T_excitation, typename T_AtomicStateDataBox, typename T_BoundBoundTransitionDataBox>
         HDINLINE static float_X rateCollisionalBoundBoundTransition(
             float_X const energyElectron, // [eV]
             float_X const energyElectronBinWidth, // [eV]

--- a/include/picongpu/particles/atomicPhysics2/rateCalculation/DebugHelperRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics2/rateCalculation/DebugHelperRateCalculation.hpp
@@ -300,7 +300,7 @@ namespace picongpu::particles::atomicPhysics2::rateCalculation::debug
             float_64 const rate
                 = static_cast<float_64>(
                       rateCalculation::BoundBoundTransitionRates<T_n_max>::
-                          template rateCollisionalBoundBoundTransition<S_AtomicStateBox, S_BoundBoundBox, true>(
+                          template rateCollisionalBoundBoundTransition<true>(
                               energyElectron,
                               energyElectronBinWidth,
                               static_cast<float_X>(densityElectrons * pmacc::math::cPow(picongpu::UNIT_LENGTH, 3u)),
@@ -320,7 +320,7 @@ namespace picongpu::particles::atomicPhysics2::rateCalculation::debug
             float_64 const rate
                 = static_cast<float_64>(
                       rateCalculation::BoundBoundTransitionRates<T_n_max>::
-                          template rateCollisionalBoundBoundTransition<S_AtomicStateBox, S_BoundBoundBox, false>(
+                          template rateCollisionalBoundBoundTransition<false>(
                               energyElectron,
                               energyElectronBinWidth,
                               static_cast<float_X>(densityElectrons * pmacc::math::cPow(picongpu::UNIT_LENGTH, 3u)),


### PR DESCRIPTION
- reduce explicit template signature configuration when calling a function
- Rename `add` to `atomic` add in rate cache to better see the difference. Atomic add does not requires synchonizing if a second stage is accesing the same memory within the kernel.